### PR TITLE
Remove date label

### DIFF
--- a/billing.rb
+++ b/billing.rb
@@ -20,7 +20,7 @@ class BillingCalculator
     Prometheus::Client.registry.gauge(
       :cost,
       docstring: 'A counter representing PaaS cost per space and resource type on the previous day',
-      labels: %i[space resource_type date]
+      labels: %i[space resource_type]
     )
   end
 
@@ -48,7 +48,7 @@ class BillingCalculator
     cost_array.each do |c|
       cost_metric.set(
         c[:price],
-        labels: { space: c[:space], resource_type: c[:resource_type], date: range_start_yesterday }
+        labels: { space: c[:space], resource_type: c[:resource_type] }
       )
     end
   end

--- a/spec/billing_calculator_spec.rb
+++ b/spec/billing_calculator_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe BillingCalculator do
     let(:metrics_response) { get '/metrics' }
     let(:cost_metrics_values) do
       <<~COST_METRICS
-        cost{space="space0",resource_type="app",date="2021-08-02"} 0.03
-        cost{space="space0",resource_type="service",date="2021-08-02"} 0.03
-        cost{space="space1",resource_type="app",date="2021-08-02"} 0.1
-        cost{space="space1",resource_type="service",date="2021-08-02"} 0.07
+        cost{space="space0",resource_type="app"} 0.03
+        cost{space="space0",resource_type="service"} 0.03
+        cost{space="space1",resource_type="app"} 0.1
+        cost{space="space1",resource_type="service"} 0.07
       COST_METRICS
     end
 
@@ -88,6 +88,5 @@ RSpec.describe BillingCalculator do
 
       expect(response.status).to eq 200
     end
-
   end
 end


### PR DESCRIPTION
## What
This label was supposed to help identify the cost with the date it
represents. But the label would have unbounded values and high
cardinality. This is not recommended in prometheus:
https://prometheus.io/docs/practices/naming/#labels

The metric have an associated timestamp anyway. We have to remember that
a timestamp identifies the cost of the PREVIOUS DAY.

## How to review
Run `make test`