### PR TITLE
Special characters in credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - master
+
+env:
+  DOCKER_REPOSITORY: ghcr.io/dfe-digital/paas-billing-exporter
+
+jobs:
+  build:
+    name: Test, build, push
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - name: Run unit tests
+      run: make test
+
+    - name: Run linting
+      run: make lint
+
+    - name: Set environment variables
+      run: |
+        GIT_REF=${{ github.ref }}
+        GIT_BRANCH=${GIT_REF##*/}
+        COMMIT_SHA=${GITHUB_SHA}
+        echo "GIT_BRANCH=${GIT_BRANCH}" >> $GITHUB_ENV
+        echo "DOCKER_IMAGE_TAG=${GIT_BRANCH}-${COMMIT_SHA}" >> $GITHUB_ENV
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push docker image
+      uses: docker/build-push-action@v2
+      with:
+        build-args: |
+          BUILDKIT_INLINE_CACHE=1
+        # Cache from image tagged with branch name, may be empty first time branch is pushed
+        # Cache from image tagged with main branch name, always present, maybe less recent
+        cache-from: |
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.GIT_BRANCH }}
+          ${{ env.DOCKER_REPOSITORY }}:main
+        push: true
+        # Tag with branch name for reuse
+        tags: |
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.GIT_BRANCH }}
+          ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   byebug

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ PORT ?= 8080
 IMAGE_TAG ?= latest
 
 test:
-	@rspec -f doc
+	@bundle exec rspec -f doc
 
 lint:
-	@rubocop --require rubocop-rspec
+	@bundle exec rubocop --require rubocop-rspec
 
 .PHONY: dev
 dev:

--- a/billing.rb
+++ b/billing.rb
@@ -4,6 +4,7 @@
 require 'net/http'
 require 'json'
 require 'prometheus/client'
+require 'English'
 
 ORG = 'dfe'
 BILLING_URL = 'https://billing.london.cloud.service.gov.uk'
@@ -14,24 +15,14 @@ PRECISION = 2
 # Rack middleware to fetch billing data from the PaaS billing API and aggregate the data into prometheus metrics
 class BillingCalculator
   def initialize(app)
-    self.class.init_paas_login
-
+    CFWrapper.init_paas_login
     @app = app
+
     Prometheus::Client.registry.gauge(
       :cost,
       docstring: 'A counter representing PaaS cost per space and resource type on the previous day',
       labels: %i[space resource_type]
     )
-  end
-
-  def self.init_paas_login
-    @skip_login = false
-    if ENV['SKIP_LOGIN'] && ENV['SKIP_LOGIN'].downcase == 'true'
-      @skip_login = true
-    else
-      @paas_username = ENV.fetch('PAAS_USERNAME')
-      @paas_password = ENV.fetch('PAAS_PASSWORD')
-    end
   end
 
   def self.aggregate_cost(token)
@@ -43,7 +34,6 @@ class BillingCalculator
 
   def self.update_cost_metric(token)
     cost_array = aggregate_cost(token)
-
     cost_metric = Prometheus::Client.registry.get(:cost)
     cost_array.each do |c|
       cost_metric.set(
@@ -54,17 +44,9 @@ class BillingCalculator
   end
 
   def call(env)
-    self.class.update_cost_metric(self.class.paas_token) if env['PATH_INFO'] == '/metrics'
+    self.class.update_cost_metric(CFWrapper.paas_token) if env['PATH_INFO'] == '/metrics'
 
     @app.call(env)
-  end
-
-  def self.paas_token
-    unless @skip_login
-      system "cf api #{API_URL}"
-      system "cf auth #{@paas_username} #{@paas_password}"
-    end
-    `cf oauth-token`.strip
   end
 
   def self.range_start_yesterday
@@ -126,6 +108,34 @@ class BillingCalculator
       end
     end
     metrics
+  end
+end
+
+# Wrapper around Cloud Foundry CLI
+class CFWrapper
+  def self.init_paas_login
+    @skip_login = false
+    if ENV['SKIP_LOGIN'] && ENV['SKIP_LOGIN'].downcase == 'true'
+      @skip_login = true
+    else
+      @paas_username = ENV.fetch('PAAS_USERNAME')
+      @paas_password = ENV.fetch('PAAS_PASSWORD')
+    end
+  end
+
+  def self.call_cf(arguments)
+    output = `cf #{arguments} 2>&1`
+    raise SystemCallError.new(output, $CHILD_STATUS.exitstatus) if $CHILD_STATUS.exitstatus != 0
+
+    output
+  end
+
+  def self.paas_token
+    unless @skip_login
+      call_cf "api #{API_URL}"
+      call_cf "auth #{@paas_username} #{@paas_password}"
+    end
+    call_cf('oauth-token').strip
   end
 end
 

--- a/billing.rb
+++ b/billing.rb
@@ -133,7 +133,7 @@ class CFWrapper
   def self.paas_token
     unless @skip_login
       call_cf "api #{API_URL}"
-      call_cf "auth #{@paas_username} #{@paas_password}"
+      call_cf "auth \"#{@paas_username}\" \"#{@paas_password}\""
     end
     call_cf('oauth-token').strip
   end

--- a/spec/billing_calculator_spec.rb
+++ b/spec/billing_calculator_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe BillingCalculator do
     before do
       mock_today_date
       mock_api_response
-      allow(described_class).to receive(:paas_token).and_return(FAKE_TOKEN)
+      allow(CFWrapper).to receive(:paas_token).and_return(FAKE_TOKEN)
     end
 
     after do

--- a/spec/cf_wrapper_spec.rb
+++ b/spec/cf_wrapper_spec.rb
@@ -24,4 +24,20 @@ RSpec.describe CFWrapper do
       expect { described_class.paas_token }.to raise_error(SystemCallError)
     end
   end
+
+  context 'when the password contains a special character' do
+    before do
+      allow(ENV).to receive(:fetch).with('PAAS_USERNAME').and_return('username')
+      allow(ENV).to receive(:fetch).with('PAAS_PASSWORD').and_return('password&')
+      allow(described_class).to receive(:`).with("cf api #{API_URL} 2>&1")
+      allow(described_class).to receive(:`).with('cf auth "username" "password&" 2>&1')
+      allow(described_class).to receive(:`).with('cf oauth-token 2>&1').and_return('something')
+    end
+
+    it 'safely escapes it' do
+      described_class.init_paas_login
+      described_class.paas_token
+      expect(described_class).to have_received(:`).with('cf auth "username" "password&" 2>&1')
+    end
+  end
 end

--- a/spec/cf_wrapper_spec.rb
+++ b/spec/cf_wrapper_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'billing'
+
+def make_last_exit_status(code)
+  `exit #{code}`
+end
+
+RSpec.describe CFWrapper do
+  context 'when a shell command fails' do
+    before do
+      allow(described_class).to receive(:`).with("cf api #{API_URL} 2>&1").and_return('failed')
+      make_last_exit_status 123
+      allow(ENV).to receive(:fetch).with('PAAS_USERNAME').and_return('username')
+      allow(ENV).to receive(:fetch).with('PAAS_PASSWORD').and_return('password')
+    end
+
+    after do
+      make_last_exit_status 0
+    end
+
+    it 'raises an error' do
+      described_class.init_paas_login
+      expect { described_class.paas_token }.to raise_error(SystemCallError)
+    end
+  end
+end


### PR DESCRIPTION
## What
Since we use the command line, special characters create issues. This escapes the strings to avoid the issue and add more error checking.

## How to review
try `cf auth username pass&word`
and `cf auth "username" "pass&word"`