### PR TITLE
Bump mathieudutour/github-tag-action to 5.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Bump version and push tag
       id: tag_version
-      uses: mathieudutour/github-tag-action@v5
+      uses: mathieudutour/github-tag-action@v5.6
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What
The tag always has the branch name
It should consider main as a release branch

## How to review
See
https://github.com/mathieudutour/github-tag-action/blob/releases/v5/action.yml#L34
And
https://github.com/mathieudutour/github-tag-action/blob/releases/v5.6/action.yml#L39